### PR TITLE
Fixed wording on How to Improve API Performance?- Caching - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Synchronous logging deals with the disk for every call and can slow down the sys
 
 Caching
 
-We can cache frequently accessed data into a cache. The client can query the cache first instead of visiting the database directly. If there is a cache miss, the client can query from the database. Caches like Redis store data in memory, so the data access is much faster than the database.
+We can store frequently accessed data into a cache. The client can query the cache first instead of visiting the database directly. If there is a cache miss, the client can query from the database. Caches like Redis store data in memory, so the data access is much faster than the database.
 
 Payload Compression
 


### PR DESCRIPTION
Changed "We can `cache` frequently accessed data into a cache." to "We can `store` frequently accessed data into a cache."