### PR TITLE
chore(deps): 1 outdated dev dep found. @types/node 22.13.14 → 22.14.0 (minor, safe). 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "cc-by-nc-sd-4.0",
   "devDependencies": {
-    "@types/node": "^22.13.14",
+    "@types/node": "^22.14.0",
     "gray-matter": "^4.0.3",
     "tsx": "^4.19.3"
   }


### PR DESCRIPTION
## 🔧 依赖维护更新 — ByteByteGoHq/system-design-101

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dev dep found. @types/node 22.13.14 → 22.14.0 (minor, safe). gray-matter 4.0.3 and tsx 4.19.3 are at current major versions — no changes needed.

### 📦 变更清单

🔴 **@types/node**: `^22.13.14` → `^22.14.0`
  _Minor version bump for Node.js type definitions (22.13 → 22.14), low risk_

### ⚠️ 风险等级
🟢 **Low**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_